### PR TITLE
Fatal error when using inputFile method

### DIFF
--- a/libraries/S3.php
+++ b/libraries/S3.php
@@ -380,7 +380,7 @@ class S3 {
 			if (isset($requestHeaders['Content-Type']))
 				$input['type'] = & $requestHeaders['Content-Type'];
 			elseif (isset($input['file']))
-				$input['type'] = $this->__getMimeType($input['file']);
+				$input['type'] = self::__getMimeType($input['file']);
 			else
 				$input['type'] = 'application/octet-stream';
 		}


### PR DESCRIPTION
Fatal error: Using $this when not in object context in /path_to/application/libraries/S3.php on line 383.

I found that if I change that line to read `$input['type'] = self::__getMimeType($input['file']);` instead, everything works.
