### PR TITLE
Correct value for CURLOPT_SSL_VERIFYHOST

### DIFF
--- a/libraries/S3.php
+++ b/libraries/S3.php
@@ -1349,7 +1349,7 @@ final class S3Request {
 
 		if (S3::$use_ssl)
 		{
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 1);
+			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
 			if (S3::$verify_peer)
 			{
 			    curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 1);


### PR DESCRIPTION
The correct value for CURLOPT_SSL_VERIFYHOST is 2, not 1.

From the libcurl documentation:

When CURLOPT_SSL_VERIFYHOST is 2, that certificate must indicate that the server is the server to which you meant to connect, or the connection fails.

Curl considers the server the intended one when the Common Name field or a Subject Alternate Name field in the certificate matches the host name in the URL to which you told Curl to connect.

When the value is 1, the certificate must contain a Common Name field, but it
doesn't matter what name it says. (This is not ordinarily a useful setting).
