### PR TITLE
Format example code in README in a code block.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -55,14 +55,16 @@ h3. Legacy methods:
 
 h2. Example Usage
 
-// Load Library
-$this->load->library('s3');
-
-// Create a Bucket
-var_dump($this->s3->putBucket('My-Bucket', $this->s3->ACL_PUBLIC_READ));
-
-// List Buckets
-var_dump($this->s3->listBuckets());
+<pre><code>
+  // Load Library
+  $this->load->library('s3');
+  
+  // Create a Bucket
+  var_dump($this->s3->putBucket('My-Bucket', $this->s3->ACL_PUBLIC_READ));
+  
+  // List Buckets
+  var_dump($this->s3->listBuckets());
+</code></pre>
 
 h2. References
 


### PR DESCRIPTION
I noticed someone on Stack Overflow had copied and pasted the example code in the README as-is, including arrow glyphs and smartened quotes, because the original wasn't wrapped in a code block. I figured formatting the example code as code would make life easier for people.
